### PR TITLE
初期化 SQL の作成

### DIFF
--- a/db/migrations/init.sql
+++ b/db/migrations/init.sql
@@ -1,0 +1,44 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email VARCHAR(255) UNIQUE NOT NULL,
+  password_hash VARCHAR(100) NOT NULL,
+  name VARCHAR(50) NOT NULL,
+  profile_image_url VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS posts (
+  id SERIAL PRIMARY KEY,
+  user_id int NOT NULL,
+  FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE SET NULL,
+  thumbnail_post_image_id int,
+  title VARCHAR(100) NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);
+CREATE INDEX ON posts (created_at);
+
+CREATE TABLE IF NOT EXISTS post_images (
+  id SERIAL PRIMARY KEY,
+  post_id int NOT NULL,
+  FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE SET NULL,
+  image_url VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);
+ALTER TABLE posts ADD FOREIGN KEY (thumbnail_post_image_id) REFERENCES post_images (id);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id SERIAL PRIMARY KEY,
+  name VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS post_to_tags (
+  post_id int NOT NULL,
+  FOREIGN KEY (post_id) REFERENCES posts (id) ON DELETE SET NULL,
+  tag_id int NOT NULL,
+  FOREIGN KEY (tag_id) REFERENCES tags (id) ON DELETE SET NULL,
+  created_at TIMESTAMP NOT NULL,
+  PRIMARY KEY (post_id, tag_id)
+);
+CREATE INDEX ON post_to_tags (tag_id);


### PR DESCRIPTION
初期化 SQL を作成しています。

ER 図で各エンティティに設定していた updated_at について、PostgreSQL での実装は function、trigger の作成が必要なようだったので、一旦 updated_at を抜いています。

以下、SQL 実行後のスキーマ詳細です。
```
test=# \d
                  List of relations
 Schema |        Name        |   Type   |    Owner    
--------+--------------------+----------+-------------
 public | post_images        | table    | you.iwamoto
 public | post_images_id_seq | sequence | you.iwamoto
 public | post_to_tags       | table    | you.iwamoto
 public | posts              | table    | you.iwamoto
 public | posts_id_seq       | sequence | you.iwamoto
 public | tags               | table    | you.iwamoto
 public | tags_id_seq        | sequence | you.iwamoto
 public | users              | table    | you.iwamoto
 public | users_id_seq       | sequence | you.iwamoto
(9 rows)

test=# \d users;
                                            Table "public.users"
      Column       |            Type             | Collation | Nullable |              Default              
-------------------+-----------------------------+-----------+----------+-----------------------------------
 id                | integer                     |           | not null | nextval('users_id_seq'::regclass)
 email             | character varying(255)      |           | not null | 
 password_hash     | character varying(100)      |           | not null | 
 name              | character varying(50)       |           | not null | 
 profile_image_url | character varying(255)      |           | not null | 
 created_at        | timestamp without time zone |           | not null | 
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
    "users_email_key" UNIQUE CONSTRAINT, btree (email)
Referenced by:
    TABLE "posts" CONSTRAINT "posts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL

test=# \d posts;
                                               Table "public.posts"
         Column          |            Type             | Collation | Nullable |              Default              
-------------------------+-----------------------------+-----------+----------+-----------------------------------
 id                      | integer                     |           | not null | nextval('posts_id_seq'::regclass)
 user_id                 | integer                     |           | not null | 
 thumbnail_post_image_id | integer                     |           |          | 
 title                   | character varying(100)      |           | not null | 
 content                 | text                        |           | not null | 
 created_at              | timestamp without time zone |           | not null | 
Indexes:
    "posts_pkey" PRIMARY KEY, btree (id)
    "posts_created_at_idx" btree (created_at)
Foreign-key constraints:
    "posts_thumbnail_post_image_id_fkey" FOREIGN KEY (thumbnail_post_image_id) REFERENCES post_images(id)
    "posts_user_id_fkey" FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
Referenced by:
    TABLE "post_images" CONSTRAINT "post_images_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE SET NULL
    TABLE "post_to_tags" CONSTRAINT "post_to_tags_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE SET NULL

test=# \d post_images;
                                        Table "public.post_images"
   Column   |            Type             | Collation | Nullable |                 Default                 
------------+-----------------------------+-----------+----------+-----------------------------------------
 id         | integer                     |           | not null | nextval('post_images_id_seq'::regclass)
 post_id    | integer                     |           | not null | 
 image_url  | character varying(255)      |           | not null | 
 created_at | timestamp without time zone |           | not null | 
Indexes:
    "post_images_pkey" PRIMARY KEY, btree (id)
Foreign-key constraints:
    "post_images_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE SET NULL
Referenced by:
    TABLE "posts" CONSTRAINT "posts_thumbnail_post_image_id_fkey" FOREIGN KEY (thumbnail_post_image_id) REFERENCES post_images(id)

test=# \d tags;
                                        Table "public.tags"
   Column   |            Type             | Collation | Nullable |             Default              
------------+-----------------------------+-----------+----------+----------------------------------
 id         | integer                     |           | not null | nextval('tags_id_seq'::regclass)
 name       | character varying(50)       |           | not null | 
 created_at | timestamp without time zone |           | not null | 
Indexes:
    "tags_pkey" PRIMARY KEY, btree (id)
Referenced by:
    TABLE "post_to_tags" CONSTRAINT "post_to_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE SET NULL

test=# \d post_to_tags;
                        Table "public.post_to_tags"
   Column   |            Type             | Collation | Nullable | Default 
------------+-----------------------------+-----------+----------+---------
 post_id    | integer                     |           | not null | 
 tag_id     | integer                     |           | not null | 
 created_at | timestamp without time zone |           | not null | 
Indexes:
    "post_to_tags_pkey" PRIMARY KEY, btree (post_id, tag_id)
    "post_to_tags_tag_id_idx" btree (tag_id)
Foreign-key constraints:
    "post_to_tags_post_id_fkey" FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE SET NULL
    "post_to_tags_tag_id_fkey" FOREIGN KEY (tag_id) REFERENCES tags(id) ON DELETE SET NULL
```