### PR TITLE
記事画像の一括更新

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "editor.formatOnPaste": true,
   "[php]": {
     "editor.defaultFormatter": "junstyle.php-cs-fixer",
     "editor.tabSize": 4

--- a/app/models/PostImage.php
+++ b/app/models/PostImage.php
@@ -39,7 +39,6 @@ class PostImage
 
             return $statement->fetch()['id'];
         } catch (Exception | ServerException $exception) {
-            var_dump($exception);
             if ($exception instanceof PDOException) {
                 throw ServerException::database($exception);
             }
@@ -65,7 +64,6 @@ class PostImage
 
             return array_map(fn ($row) => new self($row), $statement->fetchAll());
         } catch (Exception | ServerException $exception) {
-            var_dump($exception);
             if ($exception instanceof PDOException) {
                 throw ServerException::database($exception);
             }
@@ -80,6 +78,22 @@ class PostImage
             $statement = $pdo->prepare('DELETE FROM post_images WHERE id = :id');
     
             $statement->bindParam(':id', $id, PDO::PARAM_INT);
+            $statement->execute();
+        } catch (Exception | ServerException $exception) {
+            if ($exception instanceof PDOException) {
+                throw ServerException::database($exception);
+            }
+
+            throw ServerException::internal($exception);
+        }
+    }
+
+    public static function bulkDestroyByPostId(PDO $pdo, string $post_id)
+    {
+        try {
+            $statement = $pdo->prepare('DELETE FROM post_images WHERE post_id = :post_id');
+    
+            $statement->bindParam(':post_id', $post_id, PDO::PARAM_INT);
             $statement->execute();
         } catch (Exception | ServerException $exception) {
             if ($exception instanceof PDOException) {

--- a/app/public/assets/js/edit-post-images.js
+++ b/app/public/assets/js/edit-post-images.js
@@ -1,0 +1,101 @@
+const imagesFieldHtml =
+  '<input id="images" aria-describedby="post images" type="file" accept="image/*" name="images[]" multiple>';
+
+const imagesDisplay = document.getElementById('js-images-display');
+const imagesForm = document.getElementById('js-images-form');
+const editButton = document.getElementById('js-images-edit');
+const cancelEditButton = document.getElementById('js-images-cancel-edit');
+const imagesContainer = document.getElementById('js-images-container');
+const previewContainer = document.getElementById('js-preview-container');
+const form = document.getElementById('post');
+const thumbnailImageIndexField = document.getElementById('thumbnail_image_index');
+let imagesField = document.getElementById('images');
+
+if (
+  imagesDisplay === null ||
+  imagesForm === null ||
+  editButton === null ||
+  !(imagesField instanceof HTMLInputElement) ||
+  imagesField === null ||
+  previewContainer === null ||
+  form === null ||
+  thumbnailImageIndexField === null
+) {
+  throw new Error();
+}
+
+/** @type HTMLImageElement[] */
+const previewImages = [];
+
+// クリックされた画像を thumbnail_image_index フィールドにセットし、スタイルを適用
+const onClickImage = ({ target }) => {
+  if (target instanceof HTMLImageElement) {
+    previewImages.forEach((image, index) => {
+      if (image.isEqualNode(target)) {
+        if (thumbnailImageIndexField instanceof HTMLInputElement) {
+          thumbnailImageIndexField.value = index;
+        }
+
+        image.classList.add('border-teal-600');
+      } else if (image.classList.contains('border-teal-600')) {
+        image.classList.remove('border-teal-600');
+      }
+    });
+  }
+};
+
+const registerListener = () => {
+  imagesField.addEventListener('change', ({ target }) => {
+    if (target instanceof HTMLInputElement) {
+      const files = Array.from(target.files);
+
+      if (previewImages.length === 0) {
+        if (thumbnailImageIndexField instanceof HTMLInputElement) {
+          thumbnailImageIndexField.removeAttribute('value');
+        }
+      }
+
+      files.forEach((file, index) => {
+        const preview = document.createElement('img');
+        preview.setAttribute('src', window.URL.createObjectURL(file));
+        preview.setAttribute(
+          'class',
+          `w-20 cursor-pointer hover:opacity-80 border-2 border-transparent${index === 0 ? ' border-teal-600' : ''}`,
+        );
+        preview.setAttribute('alt', '添付画像のプレビュー');
+        preview.addEventListener('click', onClickImage);
+
+        previewContainer.appendChild(preview);
+        previewImages.push(preview);
+      });
+    }
+  });
+};
+
+const resetForm = () => {
+  imagesField.remove();
+  imagesContainer.innerHTML += imagesFieldHtml;
+  imagesField = imagesContainer.children[imagesContainer.children.length - 1];
+  registerListener();
+
+  thumbnailImageIndexField.value = '';
+
+  document.getElementById('js-preview-container').innerHTML = '';
+  previewImages.splice(0);
+};
+
+const showDisplay = () => {
+  imagesDisplay.hidden = false;
+  imagesForm.hidden = true;
+
+  resetForm();
+};
+const showForm = () => {
+  imagesDisplay.hidden = true;
+  imagesForm.hidden = false;
+};
+
+editButton.addEventListener('click', showForm);
+cancelEditButton.addEventListener('click', showDisplay);
+
+registerListener();

--- a/app/views/posts/edit.php
+++ b/app/views/posts/edit.php
@@ -83,6 +83,48 @@ $post = $data['post'];
                 </div>
             </div>
 
+
+            <div id="js-images-display">
+                <hr class="mt-4 pb-10">
+
+                <p class="font-bold text-xl">画像</p>
+
+                <?php if (count($data['post']->images) !== 0) : ?>
+                <div class="flex flex-wrap gap-4">
+                    <?php foreach ($data['post']->images as $image) : ?>
+                    <img src="<?= $image->image_url ?>" alt="添付画像"
+                        class="h-32 w-32">
+                    <?php endforeach ?>
+                </div>
+                <?php else : ?>
+                <p>画像はありません</p>
+                <?php endif ?>
+
+                <button type="button" id="js-images-edit" class="border p-2 mt-4">画像を編集する</button>
+            </div>
+
+            <div id="js-images-form" hidden>
+                <hr class="mt-4 pb-10">
+
+                <div id="js-images-container" class="flex flex-col">
+                    <label class="font-bold" for="images" class="block">
+                        <span>添付画像</span>
+                        <small class="pl-2">(複数選択可・png, jpg, gif 形式のファイルを指定してください)</small>
+                    </label>
+
+                    <input id="images" aria-describedby="post images" type="file" accept="image/*" name="images[]"
+                        multiple>
+                </div>
+
+                <input id="thumbnail_image_index" type="hidden" class="-mb-8" name="thumbnail_image_index">
+
+                <div id="js-preview-container" class="my-4 flex gap-2"></div>
+
+                <p class="text-red-600">※ 現在設定されている画像は全て削除された上で、このフォームで指定した画像が設定されます</p>
+                <button type="button" id="js-images-cancel-edit" class="border p-2 mt-4">画像の編集を破棄する</button>
+            </div>
+
+
             <hr class="mt-4 pb-10">
 
             <p>
@@ -96,3 +138,4 @@ $post = $data['post'];
         </form>
     </div>
 </div>
+<script src="/assets/js/edit-post-images.js"></script>

--- a/app/views/posts/edit.php
+++ b/app/views/posts/edit.php
@@ -6,7 +6,7 @@ $post = $data['post'];
 <div class="mt-10 mx-8">
     <div class="max-w-5xl mx-auto">
         <form id="post" action="/posts/<?= $post->id ?>/"
-            method="POST">
+            enctype="multipart/form-data" method="POST">
             <input type="hidden" name="_method" value="PUT">
             <input type="hidden" name="csrf_token"
                 value="<?= $data['csrf_token'] ?>">


### PR DESCRIPTION
## 内容
- [x] 記事画像の一括更新機能実装

## 相談点
- @SardineTa23  画像の追加削除をしようと思っていたのですが、僕が思いつく限りの方法で、これが結構 js にかける時間が多くなってしまいそうだったので、ひとまず、タグと同様一括更新で実装してみました。(新しく画像をアップロードした場合、既存の画像は削除され新しいものに置き換わる。) 一件ごとの追加削除は、対応する必要がありそうでしょうか？

## 備考
- 記事編集画面の js がかなり地獄のようなコードになっていますが、バックエンド研修でここに時間をかけてしまうのも良くないかと思い、とりあえず動くの状態にしています。

## デモ
https://user-images.githubusercontent.com/56625097/172106402-78c06262-80d8-41d2-8a09-5eb264cba6e2.mov


