### PR TITLE
認証状態によるアクセス制御

### DIFF
--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -1,7 +1,6 @@
 <?php
 namespace App\controllers;
 
-use App\lib\Request;
 use App\lib\Controller;
 
 class HomeController extends Controller

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -8,14 +8,8 @@ class HomeController extends Controller
 {
     const VIEW_DIR = '';
 
-    protected function beforeAction(Request $request)
+    protected function index($request)
     {
-        if ($request->isAuthenticated()) {
-            $request->redirect('/posts');
-        }
-    }
-
-    protected function index($_)
-    {
+        $request->redirect('/posts/');
     }
 }

--- a/app/controllers/PostsController.php
+++ b/app/controllers/PostsController.php
@@ -3,6 +3,7 @@ namespace App\controllers;
 
 use App\lib\Controller;
 use App\lib\ServerException;
+use App\lib\ServerExceptionName;
 use App\models\Tag;
 use App\services\post\CreateService;
 use App\services\post\DestroyService;
@@ -28,7 +29,6 @@ class PostsController extends Controller
     {
         $service = new GetService();
         $post = $service->execute($id);
-        
 
         $this->setData('post', $post);
     }
@@ -41,8 +41,6 @@ class PostsController extends Controller
 
             $request->redirect("/posts/{$post->id}");
         } catch (Exception | ServerException $exception) {
-            $this->setData('error_message', $exception instanceof ServerException ? $exception->display_text : '不明なエラーが発生しました');
-
             $index_service = new IndexService();
             $posts = $index_service->execute();
             $this->setData('posts', $posts);
@@ -53,24 +51,52 @@ class PostsController extends Controller
 
     protected function edit($request, $id)
     {
-        $service = new GetService();
-        $post = $service->execute($id);
-        $this->setData('post', $post);
+        try {
+            $current_user_id = $request->getCurrentUserId();
 
-        $tag_ids = array_map(fn (Tag $tag) => $tag->id, $post->tags);
-        $this->setData('tag_ids', $tag_ids);
+            $service = new GetService();
+            $post = $service->execute($id);
+            if ($post->user__id !== $current_user_id) {
+                throw ServerException::unauthorized();
+            }
+
+            $this->setData('post', $post);
+
+            $tag_ids = array_map(fn (Tag $tag) => $tag->id, $post->tags);
+            $this->setData('tag_ids', $tag_ids);
+        } catch (ServerException $exception) {
+            // 他のユーザーの記事の編集画面にアクセスを試行した際、記事一覧へ遷移
+            if ($exception->name === ServerExceptionName::UNAUTHORIZED) {
+                $this->setData('error_message', $exception->display_text);
+
+                // view に必要なデータの取得
+                $index_service = new IndexService();
+                $posts = $index_service->execute();
+                $this->setData('posts', $posts);
+    
+                $this->view($request, self::VIEW_DIR, 'index');
+            }
+
+            // Controller->execAction が拾う
+            throw $exception;
+        }
     }
 
     protected function update($request, $id)
     {
         try {
+            $current_user_id = $request->getCurrentUserId();
+            $get_service = new GetService();
+            $post = $get_service->execute($id);
+            if ($post->user__id !== $current_user_id) {
+                throw ServerException::unauthorized();
+            }
+            
             $service = new UpdateService();
             $service->execute($request, $id);
 
             $request->redirect("/posts/$id/");
-        } catch (Exception | ServerException $exception) {
-            $this->setData('error_message', $exception instanceof ServerException ? $exception->display_text : '不明なエラーが発生しました');
-
+        } catch (ServerException $_) {
             $get_service = new GetService();
             $post = $get_service->execute($id);
             $this->setData('post', $post);
@@ -85,7 +111,7 @@ class PostsController extends Controller
     protected function destroy($request, $id)
     {
         $service = new DestroyService();
-        $service->execute($id);
+        $service->execute($request, $id);
 
         $request->redirect('/posts/');
     }

--- a/app/controllers/PostsController.php
+++ b/app/controllers/PostsController.php
@@ -10,7 +10,6 @@ use App\services\post\DestroyService;
 use App\services\post\GetService;
 use App\services\post\IndexService;
 use App\services\post\UpdateService;
-
 use Exception;
 
 class PostsController extends Controller
@@ -41,6 +40,10 @@ class PostsController extends Controller
 
             $request->redirect("/posts/{$post->id}");
         } catch (Exception | ServerException $exception) {
+            // デフォルトでは create の例外に対して /new を表示するため、index を指定
+
+            $this->setData('error_message', $exception instanceof ServerException ? $exception->display_text : '不明なエラーが発生しました');
+
             $index_service = new IndexService();
             $posts = $index_service->execute();
             $this->setData('posts', $posts);

--- a/app/controllers/SessionsController.php
+++ b/app/controllers/SessionsController.php
@@ -9,10 +9,6 @@ class SessionsController extends Controller
 {
     const VIEW_DIR = 'sessions/';
 
-    protected function beforeAction($request)
-    {
-    }
-
     protected function new($request)
     {
         // ログイン状態の時、記事一覧画面へリダイレクト

--- a/app/controllers/SessionsController.php
+++ b/app/controllers/SessionsController.php
@@ -11,18 +11,23 @@ class SessionsController extends Controller
 
     protected function beforeAction($request)
     {
+    }
+
+    protected function new($request)
+    {
         // ログイン状態の時、記事一覧画面へリダイレクト
         if ($request->isAuthenticated()) {
             return $request->redirect('/posts');
         }
     }
 
-    protected function new($_)
-    {
-    }
-
     protected function create($request)
     {
+        // ログイン状態の時、記事一覧画面へリダイレクト
+        if ($request->isAuthenticated()) {
+            return $request->redirect('/posts');
+        }
+
         $service = new LoginService();
         $service->execute($request);
 

--- a/app/lib/Controller.php
+++ b/app/lib/Controller.php
@@ -88,7 +88,7 @@ abstract class Controller
     {
         $this->beforeAction($request);
 
-        if ($request->method === 'POST' || $request->method === 'PUT') {
+        if ($request->method === 'POST' || $request->method === 'PUT' || $request->method === 'DELETE') {
             $this->validateCsrfToken($request);
         }
 

--- a/app/lib/Controller.php
+++ b/app/lib/Controller.php
@@ -67,6 +67,7 @@ abstract class Controller
     {
         $is_authenticated = $request->isAuthenticated();
         $this->setData('is_authenticated', $is_authenticated);
+        $this->setData('current_user', $is_authenticated ? $request->getCurrentUser() : null);
 
         // CSRF token の生成・セット
         $csrf_token = bin2hex(random_bytes(32));

--- a/app/lib/Request.php
+++ b/app/lib/Request.php
@@ -69,7 +69,7 @@ class Request
     public function getCurrentUserId(): string
     {
         if (!$this->isAuthenticated()) {
-            throw ServerException::unauthorized(display_text: 'ログインしてください');
+            throw ServerException::unauthenticated(display_text: 'ログインしてください');
         }
         
         return $this->getSession('user_id');
@@ -82,7 +82,7 @@ class Request
     public function getCurrentUser(): User
     {
         if (!$this->isAuthenticated()) {
-            throw ServerException::unauthorized(display_text: 'ログインしてください');
+            throw ServerException::unauthenticated(display_text: 'ログインしてください');
         }
         
         $service = new UserGetService();

--- a/app/lib/ServerException.php
+++ b/app/lib/ServerException.php
@@ -40,7 +40,12 @@ class ServerException extends Exception
         return new self(ServerExceptionName::INVALID_REQUEST, $display_text, $inner);
     }
 
-    public static function unauthorized(?Exception $inner = null, ?string $display_text = '不正な入力です'): self
+    public static function unauthenticated(?Exception $inner = null, ?string $display_text = '不正な入力です'): self
+    {
+        return new self(ServerExceptionName::UNAUTHENTICATED, $display_text, $inner);
+    }
+
+    public static function unauthorized(?Exception $inner = null, ?string $display_text = '他のユーザーにこの操作を行うことはできません'): self
     {
         return new self(ServerExceptionName::UNAUTHORIZED, $display_text, $inner);
     }

--- a/app/lib/ServerExceptionName.php
+++ b/app/lib/ServerExceptionName.php
@@ -9,5 +9,6 @@ enum ServerExceptionName: string
     case EMAIL_ALREADY_EXISTS = 'email-already-exists';
     case INVALID_REQUEST = 'invalid-request';
     case CSRF_CHECK_FAILED = 'csrf-check-failed';
+    case UNAUTHENTICATED =  'unauthenticated';
     case UNAUTHORIZED = 'unauthorized';
 }

--- a/app/models/Post.php
+++ b/app/models/Post.php
@@ -20,6 +20,7 @@ class Post
     public readonly string $created_at;
 
     // TODO: User で管理する
+    public readonly string $user__id;
     public readonly string $user__name;
     public readonly string $user__profile_image_url;
 
@@ -37,6 +38,7 @@ class Post
         $this->created_at = $row['created_at'];
 
         // TODO: User で管理する
+        $this->user__id = $row['user__id'];
         $this->user__name = $row['user__name'];
         $this->user__profile_image_url = $row['user__profile_image_url'];
     }
@@ -83,6 +85,7 @@ class Post
                 'SELECT
                     posts.*,
                     post_images.image_url AS thumbnail_post_image_url,
+                    users.id AS user__id,
                     users.name AS user__name,
                     users.profile_image_url AS user__profile_image_url,
                     post_images
@@ -115,6 +118,7 @@ class Post
             $statement = $pdo->prepare(
                 'SELECT
                     posts.*,
+                    users.id AS user__id,
                     users.name AS user__name,
                     users.profile_image_url AS user__profile_image_url,
                     post_images.image_url AS thumbnail_post_image_url

--- a/app/models/user.php
+++ b/app/models/user.php
@@ -29,9 +29,6 @@ class User
 
     /**
      * データからレコードを作成する
-     * @param string $name
-     * @param string $email
-     * @param string $password
      * @param ?string $profile_image_url
      */
     public static function create(PDO $pdo, CreateUserDto $dto)
@@ -39,7 +36,7 @@ class User
         self::validate($dto);
 
         try {
-            $password_hash = password_hash($password, PASSWORD_DEFAULT);
+            $password_hash = password_hash($dto->password, PASSWORD_DEFAULT);
             $statement = $pdo->prepare(
                 'INSERT INTO users
                     (name, email, password_hash, profile_image_url, created_at)

--- a/app/public/assets/js/preview-multiple-images.js
+++ b/app/public/assets/js/preview-multiple-images.js
@@ -5,7 +5,7 @@ const main = () => {
   const $thumbnailImageIndexField = document.getElementById('thumbnail_image_index');
 
   if ($imageInput === null || $previewContainer === null || $form === null || $thumbnailImageIndexField === null) {
-    throw new Error();
+    return;
   }
 
   /** @type HTMLImageElement[] */

--- a/app/public/assets/js/toggle.js
+++ b/app/public/assets/js/toggle.js
@@ -1,20 +1,24 @@
-const $toggleButton = document.getElementById('js-toggle-button');
-const $toggleBody = document.getElementById('js-toggle-body');
+const toggle = () => {
+  const $toggleButton = document.getElementById('js-toggle-button');
+  const $toggleBody = document.getElementById('js-toggle-body');
 
-if ($toggleButton === null || $toggleBody === null) {
-  throw new Error();
-}
-
-let isOpen = true;
-
-$toggleButton.addEventListener('click', () => {
-  if (isOpen) {
-    $toggleBody.classList.add('h-0');
-    $toggleButton.classList.add('rotate-180');
-    isOpen = false;
-  } else {
-    $toggleBody.classList.remove('h-0');
-    $toggleButton.classList.remove('rotate-180');
-    isOpen = true;
+  if ($toggleButton === null || $toggleBody === null) {
+    return;
   }
-});
+
+  let isOpen = true;
+
+  $toggleButton.addEventListener('click', () => {
+    if (isOpen) {
+      $toggleBody.classList.add('h-0');
+      $toggleButton.classList.add('rotate-180');
+      isOpen = false;
+    } else {
+      $toggleBody.classList.remove('h-0');
+      $toggleButton.classList.remove('rotate-180');
+      isOpen = true;
+    }
+  });
+};
+
+toggle();

--- a/app/services/post/CreateService.php
+++ b/app/services/post/CreateService.php
@@ -40,9 +40,9 @@ class CreateService extends Service
                 PostToTag::create($pdo, $post->id, $tag_id);
             }
 
-            if (isset($request->files['images'])) {
-                // 画像の作成
-                $uploaded_images = $request->files['images'];
+            $uploaded_images = $request->files['images'];
+            $is_uploaded_images_empty = $uploaded_images['tmp_name'][0] === '';
+            if (!$is_uploaded_images_empty) {
                 // アップロードされた枚数分繰り返し
                 // TODO: O(n) の回避
                 for ($index = 0; $index < count($uploaded_images['tmp_name']); $index ++) {

--- a/app/services/post/DestroyService.php
+++ b/app/services/post/DestroyService.php
@@ -1,16 +1,24 @@
 <?php
 namespace App\services\post;
 
+use App\lib\Request;
+use App\lib\ServerException;
 use App\models\Post;
 use App\services\concerns\Service;
 
 class DestroyService extends Service
 {
-    public function execute(string $id)
+    public function execute(Request $request, string $id)
     {
         $pdo = $this->pdo;
 
         $post = Post::getById($pdo, $id);
+
+        $current_user_id = $request->getCurrentUserId();
+        // 記事の作成者か確認
+        if ($post->user__id !== $current_user_id) {
+            throw ServerException::unauthorized();
+        }
 
         $post->destroy($pdo);
     }

--- a/app/services/post/UpdateService.php
+++ b/app/services/post/UpdateService.php
@@ -52,7 +52,9 @@ class UpdateService extends Service
             }
 
             $current_post_image_urls = [];
-            if (isset($request->files['images'])) {
+            $uploaded_images = $request->files['images'];
+            $is_uploaded_images_empty = $uploaded_images['tmp_name'][0] === '';
+            if (!$is_uploaded_images_empty) {
                 // 現在の画像のパスをデータ削除前に取得しておき、トランザクションのコミット後に削除を試行
                 // (トランザクションをロールバックした場合、画像削除はロールバックできないため)
                 $current_post_image_urls = array_map(fn ($post_image) => $post_image->image_url, PostImage::getAllByPostId($pdo, $id));
@@ -62,8 +64,6 @@ class UpdateService extends Service
                 // DB から PostImage を削除
                 PostImage::bulkDestroyByPostId($pdo, $id);
 
-                // 画像の作成
-                $uploaded_images = $request->files['images'];
                 // アップロードされた枚数分繰り返し
                 // TODO: O(n) の回避
                 for ($index = 0; $index < count($uploaded_images['tmp_name']); $index ++) {

--- a/app/services/session/LogoutService.php
+++ b/app/services/session/LogoutService.php
@@ -8,8 +8,6 @@ class LogoutService extends Service
 {
     public function execute(Request $request)
     {
-        $request = $this->request;
-
         $request->unsetSession('user_id');
     }
 }

--- a/app/views/index.php
+++ b/app/views/index.php
@@ -4,7 +4,7 @@
             <span class="whitespace-nowrap">KENSHU TIMESでは</span>
             <span class="whitespace-nowrap">なんと、画像付きの記事が投稿できます</span>
         </p>
-        <div class="flex justify-center gap-8 my-10">
+        <div class="flex justify-center gap-8 mt-10">
             <div class="text-center">
                 <p class="mb-2">まずは</p>
                 <a class="text-white px-4 py-2 bg-teal-600 inline-block hover:bg-teal-500 rounded-lg transition-colors"
@@ -15,6 +15,11 @@
                 <a class="text-teal-600 px-4 py-2 border border-teal-600 inline-block hover:bg-teal-50 rounded-lg transition-colors"
                     href="/sessions/new/">ログイン</a>
             </div>
+        </div>
+
+        <div class="text-center mt-16">
+            <a href="/posts"
+                class="border-2 text-xl text-gray-800 rounded-lg border-teal-600 p-4  hover:bg-teal-50 transition-colors">登録せずに記事を閲覧する</a>
         </div>
     </div>
 </div>

--- a/app/views/partials/header.php
+++ b/app/views/partials/header.php
@@ -23,6 +23,14 @@ class Header
         </button>
     </form>
 
+    <?php else : ?>
+    <div class="flex justify-center gap-8">
+        <a class="text-white px-4 py-2 bg-teal-600 inline-block hover:bg-teal-500 rounded-lg transition-colors"
+            href="/users/new/">新規会員登録</a>
+        <a class="text-teal-600 px-4 py-2 border border-teal-600 inline-block hover:bg-teal-50 rounded-lg transition-colors"
+            href="/sessions/new/">ログイン</a>
+    </div>
+
     <?php endif ?>
 
 </header>

--- a/app/views/posts/index.php
+++ b/app/views/posts/index.php
@@ -1,5 +1,8 @@
 <div class="mt-10 mx-4">
     <div class="max-w-5xl mx-auto">
+
+        <?php if ($data['is_authenticated']) : ?>
+
         <section class="mb-12">
             <div class="flex justify-between items-center">
                 <h1 class="mb-4 text-lg">記事投稿</h1>
@@ -72,6 +75,8 @@
 
         <hr class="mb-6">
 
+        <?php endif ?>
+
         <section class="mb-20">
             <h1 class="mb-8 text-lg">記事一覧</h1>
             <div class="flex justify-around flex-wrap flex-grow gap-8">
@@ -103,6 +108,8 @@
                                     <?= htmlspecialchars($post->user__name) ?>
                                 </span>
                             </p>
+
+                            <?php if ($data['is_authenticated'] && $post->user__id === $data['current_user']->id) : ?>
                             <form class="relative"
                                 action="/posts/<?= $post->id ?>/"
                                 method="POST">
@@ -116,6 +123,8 @@
                                     <img class="h-6 w-6" src="/assets/img/trash.png">
                                 </button>
                             </form>
+                            <?php endif ?>
+
                         </div>
                     </div>
                 </a>

--- a/app/views/posts/index.php
+++ b/app/views/posts/index.php
@@ -1,8 +1,6 @@
 <div class="mt-10 mx-4">
     <div class="max-w-5xl mx-auto">
 
-        <?php if ($data['is_authenticated']) : ?>
-
         <section class="mb-12">
             <div class="flex justify-between items-center">
                 <h1 class="mb-4 text-lg">記事投稿</h1>
@@ -74,8 +72,6 @@
         </section>
 
         <hr class="mb-6">
-
-        <?php endif ?>
 
         <section class="mb-20">
             <h1 class="mb-8 text-lg">記事一覧</h1>

--- a/app/views/posts/show.php
+++ b/app/views/posts/show.php
@@ -39,6 +39,7 @@
                 </p>
             </div>
 
+            <?php if ($data['is_authenticated'] && $post->user__id === $data['current_user']->id) : ?>
             <div class="flex items-start gap-4">
                 <form class="relative"
                     action="/posts/<?= $post->id ?>/" method="POST">
@@ -61,6 +62,7 @@
                     </a>
                 </span>
             </div>
+            <?php endif ?>
         </div>
 
         <?php if (count($data['post']->images) !== 0) : ?>


### PR DESCRIPTION
## 内容
- [x]  ユーザー登録画面を用意して、「Sign Up」ボタンを押すと入力された値がデータベースに保存され、投稿一覧画面にログイン状態で遷移すること。
- [x]  ユーザーは登録画面で名前・メールアドレス・パスワード・プロフィール画像を登録できる。また、名前・メールアドレス・パスワードに関しては必須の項目として、空欄であるとエラーとなり登録できない。
- [x]  ユーザーログイン画面で、登録してあるユーザーのemailとパスワードをフォームに入力して「Sign In」ボタンを押すと、投稿一覧画面にログイン状態で遷移すること。
- [x]  ユーザー機能を追加後は、ユーザーログイン中でないと投稿できない状態にすること。「Submit」ボタンをおすと「ログインが必要です」のエラーメッセージを表示させる。
- [x]  投稿の編集、更新、削除は他のユーザーは行えない状態にすること。他人の投稿を編集、更新、削除するためのURLを叩くと、投稿一覧ページに遷移して「他のユーザーの投稿は、編集、更新、削除できません」のエラーメッセージを表示させる。
- [x]  投稿一覧と詳細に、それぞれどのユーザーが投稿したかわかるように、投稿したユーザーの名前が表示されること。

## デモ
テストを書いていないため、DELETE リクエストなどは確かめられていませんが、ブラウザから通常のモーションでアクセスされうる GET、POST の部分に関しては動画で以下の点を手動で確認しています。
- ログアウト状態で記事が閲覧できること
- 記事を投稿したユーザー名・アイコンが表示されていること
- ログイン中のユーザー自身が投稿した記事のみ、削除・編集ボタンが表示されること
- ログイン中のユーザー自身が投稿したものでない記事の編集画面へアクセスした際、「他のユーザーにこの操作を行うことはできません」のメッセージと一覧画面が表示されること
- ログインしていない状態で記事を投稿しようとすると、「ログインしてください」のメッセージと一覧画面が表示されること

https://user-images.githubusercontent.com/56625097/172278195-3e8a2fd5-74bc-4c5e-b5a7-5ea114ade349.mov

動画で確かめられていない以下の点についても実装しています。
- 投稿者以外からの記事の編集 (PUT)、削除 (DELETE) リクエストが失敗すること

ただし、これは通常のブラウザ上の動きでは想定していないリクエストなので、ビューにきれいに反映させるような実装はしておらず、リクエストの失敗にとどめています。